### PR TITLE
handle multiline messages better

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.6.6</version>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
Send the lines below the first line as an attachment. This allows too
long messages are folded automatically.