### PR TITLE
support webhook uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Add SlackAppender configuration to logback.xml file
 		<appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
 			<!-- Slack API token -->
 			<token>1111111111-1111111-11111111-111111111</token>
+			<!-- Slack incoming webhook uri. Uncomment the lines below to use incoming webhook uri instead of API token. -->
+			<!--
+			<webhookUri>https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX</webhookUri>
+			-->
 			<!-- Channel that you want to post - default is #general -->
 			<channel>#api-test</channel>
 			<!-- Formatting (you can use Slack formatting - URL links, code formatting, etc.) -->

--- a/src/main/java/com/github/maricn/logback/SlackAppender.java
+++ b/src/main/java/com/github/maricn/logback/SlackAppender.java
@@ -1,20 +1,23 @@
 package com.github.maricn.logback;
 
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.Layout;
-import ch.qos.logback.core.LayoutBase;
-import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Layout;
+import ch.qos.logback.core.LayoutBase;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
 
 public class SlackAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
@@ -27,6 +30,7 @@ public class SlackAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         }
     };
 
+    private String webhookUri;
     private String token;
     private String channel;
     private String username;
@@ -38,50 +42,83 @@ public class SlackAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     @Override
     protected void append(final ILoggingEvent evt) {
         try {
-            final URL url = new URL(API_URL);
-
-            final StringWriter requestParams = new StringWriter();
-            requestParams.append("token=").append(token).append("&");
-            String[] parts = layout.doLayout(evt).split("\n", 2);
-            requestParams.append("text=").append(URLEncoder.encode(parts[0], "UTF-8")).append('&');
-
-            // Send the lines below the first line as an attachment.
-            if (parts.length > 1) {
-                Map<String, String> attachment = new HashMap<>();
-                attachment.put("text", parts[1]);
-                List<Map<String, String>> attachments = Collections.singletonList(attachment);
-                String json = new ObjectMapper().writeValueAsString(attachments);
-                requestParams.append("attachments=").append(URLEncoder.encode(json, "UTF-8")).append('&');
+            if (webhookUri != null) {
+                sendMessageWithWebhookUri(evt);
+            } else {
+                sendMessageWithToken(evt);
             }
-            if (channel != null) {
-                requestParams.append("channel=").append(URLEncoder.encode(channel, "UTF-8")).append('&');
-            }
-            if (username != null) {
-                requestParams.append("username=").append(URLEncoder.encode(username, "UTF-8")).append('&');
-            }
-            if (iconEmoji != null) {
-                requestParams.append("icon_emoji=").append(URLEncoder.encode(iconEmoji, "UTF-8"));
-            }
-
-            final byte[] bytes = requestParams.toString().getBytes("UTF-8");
-
-            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setConnectTimeout(timeout);
-            conn.setReadTimeout(timeout);
-            conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
-            conn.setFixedLengthStreamingMode(bytes.length);
-            conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-
-            final OutputStream os = conn.getOutputStream();
-            os.write(bytes);
-
-            os.flush();
-            os.close();
         } catch (Exception ex) {
             ex.printStackTrace();
             addError("Error posting log to Slack.com (" + channel + "): " + evt, ex);
         }
+    }
+
+    private void sendMessageWithWebhookUri(final ILoggingEvent evt) throws IOException {
+        String[] parts = layout.doLayout(evt).split("\n", 2);
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("channel", channel);
+        message.put("username", username);
+        message.put("icon_emoji", iconEmoji);
+        message.put("text", parts[0]);
+
+        // Send the lines below the first line as an attachment.
+        if (parts.length > 1) {
+            Map<String, String> attachment = new HashMap<>();
+            attachment.put("text", parts[1]);
+            message.put("attachments", Arrays.asList(attachment));
+        }
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        final byte[] bytes = objectMapper.writeValueAsBytes(message);
+
+        postMessage(webhookUri, "application/json", bytes);
+    }
+
+    private void sendMessageWithToken(final ILoggingEvent evt) throws IOException {
+        final StringWriter requestParams = new StringWriter();
+        requestParams.append("token=").append(token).append("&");
+
+        String[] parts = layout.doLayout(evt).split("\n", 2);
+        requestParams.append("text=").append(URLEncoder.encode(parts[0], "UTF-8")).append('&');
+
+        // Send the lines below the first line as an attachment.
+        if (parts.length > 1) {
+            Map<String, String> attachment = new HashMap<>();
+            attachment.put("text", parts[1]);
+            List<Map<String, String>> attachments = Collections.singletonList(attachment);
+            String json = new ObjectMapper().writeValueAsString(attachments);
+            requestParams.append("attachments=").append(URLEncoder.encode(json, "UTF-8")).append('&');
+        }
+        if (channel != null) {
+            requestParams.append("channel=").append(URLEncoder.encode(channel, "UTF-8")).append('&');
+        }
+        if (username != null) {
+            requestParams.append("username=").append(URLEncoder.encode(username, "UTF-8")).append('&');
+        }
+        if (iconEmoji != null) {
+            requestParams.append("icon_emoji=").append(URLEncoder.encode(iconEmoji, "UTF-8"));
+        }
+
+        final byte[] bytes = requestParams.toString().getBytes("UTF-8");
+
+        postMessage(API_URL, "application/x-www-form-urlencoded", bytes);
+    }
+
+    private void postMessage(String uri, String contentType, byte[] bytes) throws IOException {
+        final HttpURLConnection conn = (HttpURLConnection) new URL(uri).openConnection();
+        conn.setConnectTimeout(timeout);
+        conn.setReadTimeout(timeout);
+        conn.setDoOutput(true);
+        conn.setRequestMethod("POST");
+        conn.setFixedLengthStreamingMode(bytes.length);
+        conn.setRequestProperty("Content-Type", contentType);
+
+        final OutputStream os = conn.getOutputStream();
+        os.write(bytes);
+
+        os.flush();
+        os.close();
     }
 
     public String getToken() {
@@ -133,6 +170,14 @@ public class SlackAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     public void setTimeout(int timeout) {
         this.timeout = timeout;
+    }
+
+    public String getWebhookUri() {
+        return webhookUri;
+    }
+
+    public void setWebhookUri(String webhookUri) {
+        this.webhookUri = webhookUri;
     }
 
 }


### PR DESCRIPTION
This allows users to specify an incoming webhook uri to send slack
messages as follows:

    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
        <!-- Slack webhook uri -->
        <webhookUri>https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX</webhookUri>
        ...
    </appender>

Ignore slack token if webhook uri is specified.

This fixes https://github.com/maricn/logback-slack-appender/issues/5.