### PR TITLE
Messages color coding by message level and wait for proper configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Add SlackAppender configuration to logback.xml file
 			<username>${HOSTNAME}</username>
 			<!-- Emoji to be used for messages -->
 			<iconEmoji>:stuck_out_tongue_winking_eye:</iconEmoji>
+			<!-- If color coding of log levels should be used -->
+			<colorCoding>true</colorCoding>
 		</appender>
 
 		<!-- Currently recommended way of using Slack appender -->

--- a/src/main/java/com/github/maricn/logback/SlackAppender.java
+++ b/src/main/java/com/github/maricn/logback/SlackAppender.java
@@ -45,7 +45,7 @@ public class SlackAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         try {
             if (webhookUri != null && !webhookUri.isEmpty()) {
                 sendMessageWithWebhookUri(evt);
-            } else if (token != null && !token.isEmpty()){
+            } else if (token != null && !token.isEmpty()) {
                 sendMessageWithToken(evt);
             }
         } catch (Exception ex) {
@@ -62,14 +62,15 @@ public class SlackAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         message.put("username", username);
         message.put("icon_emoji", iconEmoji);
         message.put("text", parts[0]);
-        if (colorCoding) {
-            message.put("color", colorByEvent(evt));
-        }
 
         // Send the lines below the first line as an attachment.
         if (parts.length > 1 && parts[1].length() > 0) {
             Map<String, String> attachment = new HashMap<>();
             attachment.put("text", parts[1]);
+            if (colorCoding) {
+                attachment.put("color", colorByEvent(evt));
+            }
+
             message.put("attachments", Collections.singletonList(attachment));
         }
 


### PR DESCRIPTION
Hi,

In this PR I've updated the appender code to work only if either webhook url or token is set. My use case is that connection parameters are set via configuration during the launch, and I don't want it to fail when the application is run on local environment whose user don't want to spam slack channel with own exceptions.

Also added color coding for different message log levels, can be enabled separately.